### PR TITLE
updating the github action version numbers to get rid of warnings

### DIFF
--- a/.github/workflows/tf-apply.yaml
+++ b/.github/workflows/tf-apply.yaml
@@ -8,9 +8,9 @@ jobs:
   terraform-apply:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v1
+      uses: hashicorp/setup-terraform@v3
       with:
         terraform_version: 1.9.1
 

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -14,9 +14,9 @@ jobs:
   terraform-plan:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v1
+      uses: hashicorp/setup-terraform@v3
       with:
         terraform_version: 1.9.1
 


### PR DESCRIPTION
The GitHub actions that I used for `actions/checkout` and `hashicorp/setup-terraform` were on outdated versions. This was causing a warning to appear in the pipeline. This should correct that issue.